### PR TITLE
fix compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -9,5 +9,5 @@ services:
         target: "/app"
     tty: true
     stdin_open: true
-    # command: bash -c "cd /portfolio && npm install && npm run dev"
+    command: bash -c "cd /portfolio && yarn && yarn dev"  
     


### PR DESCRIPTION
パッケージ管理ツールにyarnを使用することにしたため、command節を修正し、コメントアウトを解除した